### PR TITLE
Allow OTS receipt download

### DIFF
--- a/singlefile-woleet/index.html
+++ b/singlefile-woleet/index.html
@@ -85,7 +85,12 @@
                                 <br>
                                 <img src="img/download.png"/><a onclick="downloadProof({{index}})"
                                     target="blank">
-                                    Download proof receipt
+                                    Download proof receipt (Chainpoint v2) 
+                                </a>
+                                <br>
+                                <img src="img/download.png"/><a href="https://api.woleet.io/v1/receipt/{{anchorId}}/ots"
+                                    target="blank">
+                                    Download proof receipt (Opentimestamps) 
                                 </a>
                             {{/receipt.anchors.0}}
                         </div>


### PR DESCRIPTION
So far, SingleFile verification website only allowed receipt download in Chainpoint V2 format. This PR adds the ability to download the receipt in the Opentimestamps format.
